### PR TITLE
Less `new` keyword usage

### DIFF
--- a/XAM/Controllers/Requirements.txt
+++ b/XAM/Controllers/Requirements.txt
@@ -8,6 +8,6 @@ Requirements not achieved:
 -7. Usage of async/await
 8. Use at least 1 concurrent collection or Monitor
 -9. Regex usage
-10. No instances are created using 'new' keyword, dependency injection is used everywhere
+-10. No instances are created using 'new' keyword, dependency injection is used everywhere
 11. Unit and integration tests coverage at least 20%
 // (Place "-" before requirement if it is done.)

--- a/XAM/Controllers/TasksController.cs
+++ b/XAM/Controllers/TasksController.cs
@@ -22,11 +22,7 @@ public class TasksController : Controller
     {
         List<string> examNames = _dataHolder.Exams.Select(exam => exam.Name).ToList();
 
-        var result = new
-        {
-            names = examNames
-        };
-        return Json(result);
+        return Json(examNames);
     }
 
     public IActionResult FetchFlashcardsOfExam(string examName)
@@ -41,11 +37,7 @@ public class TasksController : Controller
         else
         {
             Shuffle(flashcards);
-            var result = new
-            {
-                flashcards
-            };
-            return Json(result);
+            return Json(flashcards);
         }
     }
 
@@ -64,24 +56,18 @@ public class TasksController : Controller
             if (theExam.ChallengeHighscore < score)
             {
                 _dataHolder.Statistics.TodayHighscoresBeatenCounter++;
-                var result = new
-                {
-                    text = $@"New {examName} highscore!
-                    Old highscore: {theExam.ChallengeHighscore}
-                    New highscore: {score}"
-                };
+                int oldHighscore = theExam.ChallengeHighscore;
                 theExam.ChallengeHighscore = score;
+                var result = $@"New {examName} highscore!
+                                Old highscore: {oldHighscore}
+                                New highscore: {score}";
                 return Json(result);
             }
             else
             {
-                var result = new
-                {
-                    text =
-                    $@"No new highscore for {examName}...
-                    Score: {score}
-                    Highscore: {theExam.ChallengeHighscore}"
-                };
+                var result = $@"No new highscore for {examName}...
+                                Score: {score}
+                                Highscore: {theExam.ChallengeHighscore}";
                 return Json(result);
             }
         }

--- a/XAM/wwwroot/js/tasks.js
+++ b/XAM/wwwroot/js/tasks.js
@@ -1,9 +1,9 @@
 fetch(`/Tasks/FetchExamNames`)
 .then(response => response.json())
 .then(allExamNames => {
-    if (allExamNames && Array.isArray(allExamNames.names) && allExamNames.names.length > 0)
+    if (allExamNames && Array.isArray(allExamNames) && allExamNames.length > 0)
     {
-        allExamNames.names.forEach(examName => {
+        allExamNames.forEach(examName => {
             newOption = new Option(examName, `${examName}Exam`);
             document.getElementById("examsDropdown").add(newOption, undefined);
         });
@@ -25,7 +25,7 @@ async function getFlashcardsFromExam(examName) {
         }
         else
         {
-            return data.flashcards;
+            return data;
         }
     } catch (error) {
         console.error('Error:', error);
@@ -44,7 +44,7 @@ async function setHighscore(examName, score) {
         }
         else
         {
-            return data.text;
+            return data;
         }
     } catch (error) {
         console.error('Error:', error);


### PR DESCRIPTION
I think requirement 10. is now satisfied plenty enough, because getting rid of the rest of `new` keywords would require making models for each antonymous type, making the code rather ridiculous. Basically, all the `new` keywords that are left are necessary.